### PR TITLE
Adds a BRANCH option to GitHub config options 

### DIFF
--- a/backup.cfg
+++ b/backup.cfg
@@ -37,6 +37,7 @@ BREAK=
 ## GitHub user and repository name
 USER=
 REPO=
+BRANCH=
 ##
 ## File paths for cloud backup
 REMOTE=

--- a/git_repo.sh
+++ b/git_repo.sh
@@ -22,9 +22,13 @@ fi
 ## Getting necessary information
 read -p 'Please enter your GitHub Username: ' USER
 read -p 'Please enter the name of your GitHub repository: ' REPO
+read -p 'Please enter the name of your GitHub branch (main): ' BRANCH
+
+BRANCH=${BRANCH:-main}
 
 sed -i "s/^USER=.*/USER=$USER/g" "$HOME/.config/klipper_backup_script/backup.cfg"
 sed -i "s/^REPO=.*/REPO=$REPO/g" "$HOME/.config/klipper_backup_script/backup.cfg"
+sed -i "s/^BRANCH=.*/BRANCH=$BRANCH/g" "$HOME/.config/klipper_backup_script/backup.cfg"
 
 URL="https://github.com/$USER/$REPO"
 
@@ -81,7 +85,7 @@ fi
 ## Initializing repo
 echo ""
 echo "Initializing repo"
-git -C "$HOME/klipper_config" init
+git -C "$HOME/klipper_config" init --initial-branch=$BRANCH
 git -C "$HOME/klipper_config" remote add origin "$URL"
 git -C "$HOME/klipper_config" remote set-url origin git@github.com:"$USER"/"$REPO".git
 

--- a/klipper_config_git_backup.sh
+++ b/klipper_config_git_backup.sh
@@ -92,7 +92,7 @@ do
 			echo "[$(date '+%F %T')]: Committing to GitHub repository" | tee -a "$HOME/backup_log/$(date +%F).log"
 			git -C "$HOME/klipper_config" commit -m "backup $(date +%F)" | tee -a "$HOME/backup_log/$(date +%F).log"
 			echo "[$(date '+%F %T')]: Pushing" | tee -a "$HOME/backup_log/$(date +%F).log"
-			git -C "$HOME/klipper_config" push -u origin master | tee -a "$HOME/backup_log/$(date +%F).log"
+			git -C "$HOME/klipper_config" push -u origin $BRANCH | tee -a "$HOME/backup_log/$(date +%F).log"
 			;;
 		10)
 			## Google Drive
@@ -107,7 +107,7 @@ do
 	                echo "[$(date '+%F %T')]: Committing to GitHub repository" | tee -a "$HOME/backup_log/$(date +%F).log"
 	                git -C "$HOME/klipper_config" commit -m "backup $(date +%F)" | tee -a "$HOME/backup_log/$(date +%F).log"
 	                echo "[$(date '+%F %T')]: Pushing" | tee -a "$HOME/backup_log/$(date +%F).log"
-	                git -C "$HOME/klipper_config" push -u origin master | tee -a "$HOME/backup_log/$(date +%F).log"
+	                git -C "$HOME/klipper_config" push -u origin $BRANCH | tee -a "$HOME/backup_log/$(date +%F).log"
 			echo "[$(date '+%F %T')]: Backing up to Cloud storage provider" | tee -a "$HOME/backup_log/$(date +%F).log"
 	                rclone copy "$HOME/klipper_config" "$REMOTE":"$FOLDER" --exclude "/.git/**" --transfers=1 --log-file="$HOME/backup_log/$(date +%F).log" --log-level=INFO
 	                ;;


### PR DESCRIPTION
- Adds a branch option for users not wanting to place everything on master
- Updates default branch to main to account for current GitHub default
  on new repos
- Explicitly sets initial branch for backup repo on creation